### PR TITLE
Display time in MM:SS format

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,8 @@ set -g @pomodoro_complete " ✅"             # The formatted output when the bre
 
 set -g @pomodoro_notifications 'off'        # Enable desktop notifications from your terminal
 set -g @pomodoro_sound 'off'                # Sound for desktop notifications (Run `ls /System/Library/Sounds` for a list of sounds to use on Mac)
-set -g @pomodoro_granularity_seconds 'off'  # Enables MM:SS (ex: 00:10) format instead of the default (ex: 1m)
+
+set -g @pomodoro_granularity 'off'          # Enables MM:SS (ex: 00:10) format instead of the default (ex: 1m)
 ```
 
 > :bangbang: On Linux, notifications depend on `notify-send/libnotify-bin`
@@ -93,6 +94,11 @@ The output from the plugin can be completely customised to fit in with your stat
 ```bash
 set -g @pomodoro_on "#[fg=$text_red]🍅 "
 set -g @pomodoro_complete "#[fg=$text_green]🍅 "
+
+set -g @pomodoro_granularity 'on'
+# Optional - Add this to make sure tmux refreshes the status line every second
+# needed when 'pomodoro_granularity' is 'on'
+set -g status-interval 1
 ```
 
 ## :microscope: How it works

--- a/README.md
+++ b/README.md
@@ -69,18 +69,19 @@ set -g status-right "#{pomodoro_status}"
 The default configuration:
 
 ```bash
-set -g @pomodoro_start 'p'              # Start a Pomodoro with tmux-prefix + p
-set -g @pomodoro_cancel 'P'             # Cancel a Pomodoro with tmux-prefix key + P
+set -g @pomodoro_start 'p'                  # Start a Pomodoro with tmux-prefix + p
+set -g @pomodoro_cancel 'P'                 # Cancel a Pomodoro with tmux-prefix key + P
 
-set -g @pomodoro_mins 25                # The duration of the pomodoro
-set -g @pomodoro_break_mins 5           # The duration of the break after the pomodoro
+set -g @pomodoro_mins 25                    # The duration of the pomodoro
+set -g @pomodoro_break_mins 5               # The duration of the break after the pomodoro
 set -g @pomodoro_repeat false               # Auto-repeat the pomodoro? False by default
 
-set -g @pomodoro_on " 🍅"               # The formatted output when the pomodoro is running
-set -g @pomodoro_complete " ✅"         # The formatted output when the break is running
+set -g @pomodoro_on " 🍅"                   # The formatted output when the pomodoro is running
+set -g @pomodoro_complete " ✅"             # The formatted output when the break is running
 
-set -g @pomodoro_notifications 'off'    # Enable desktop notifications from your terminal
-set -g @pomodoro_sound 'off'            # Sound for desktop notifications (Run `ls /System/Library/Sounds` for a list of sounds to use on Mac)
+set -g @pomodoro_notifications 'off'        # Enable desktop notifications from your terminal
+set -g @pomodoro_sound 'off'                # Sound for desktop notifications (Run `ls /System/Library/Sounds` for a list of sounds to use on Mac)
+set -g @pomodoro_granularity_seconds 'off'  # Enables MM:SS (ex: 00:10) format instead of the default (ex: 1m)
 ```
 
 > :bangbang: On Linux, notifications depend on `notify-send/libnotify-bin`

--- a/README.md
+++ b/README.md
@@ -94,11 +94,13 @@ The output from the plugin can be completely customised to fit in with your stat
 ```bash
 set -g @pomodoro_on "#[fg=$text_red]🍅 "
 set -g @pomodoro_complete "#[fg=$text_green]🍅 "
+```
 
+A more detailed, second by second, countdown can also be enabled in the status line:
+
+```bash
 set -g @pomodoro_granularity 'on'
-# Optional - Add this to make sure tmux refreshes the status line every second
-# needed when 'pomodoro_granularity' is 'on'
-set -g status-interval 1
+set -g status-interval 1            # Refresh the status line every second
 ```
 
 ## :microscope: How it works

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -1,7 +1,9 @@
+#!/usr/bin/env bash
+
 get_tmux_option() {
 	local option=$1
 	local default_value=$2
-	local option_value=$(tmux show-option -gqv "$option")
+	option_value=$(tmux show-option -gqv "$option")
 	if [ -z "$option_value" ]; then
 		echo "$default_value"
 	else
@@ -17,8 +19,8 @@ set_tmux_option() {
 
 read_file() {
 	local file=$1
-	if [ -f $1 ]; then
-		cat $1
+	if [ -f "$1" ]; then
+		cat "$1"
 	else
 		echo -1
 	fi
@@ -26,8 +28,8 @@ read_file() {
 
 remove_file() {
 	local file=$1
-	if [ -f $file ]; then
-		rm $file
+	if [ -f "$file" ]; then
+		rm "$file"
 	fi
 }
 

--- a/scripts/pomodoro.sh
+++ b/scripts/pomodoro.sh
@@ -13,6 +13,7 @@ pomodoro_auto_restart="@pomodoro_auto_restart"
 pomodoro_on="@pomodoro_on"
 pomodoro_complete="@pomodoro_complete"
 pomodoro_notifications="@pomodoro_notifications"
+pomodoro_granularity_seconds="@pomodoro_granularity_seconds"
 pomodoro_sound="@pomodoro_sound"
 pomodoro_on_default=" 🍅"
 pomodoro_complete_default=" ✅"
@@ -37,21 +38,26 @@ get_seconds() {
 	date +%s
 }
 
-# Formats seconds to MM:SS format
-# Example 1: 0  sec  => 00:00
-# Example 2: 59 sec => 00:59
-# Example 3: 60 sec => 01:00
 format_seconds() {
-	# TODO: only format it based on option
-	# if [ "$(get_notifications)" == 'on' ]; then
-	# fi
-
 	local total_seconds=$1
 	local minutes=$((total_seconds / 60))
 	local seconds=$((total_seconds % 60))
 
-	# Pad minutes and seconds with zeros if necessary
-	printf "%02d:%02d\n" $minutes $seconds
+	if [ "$(get_pomodoro_granularity_seconds)" == 'on' ]; then
+		# Pad minutes and seconds with zeros if necessary
+		# Formats seconds to MM:SS format
+		# Example 1: 0  sec => 00:00
+		# Example 2: 59 sec => 00:59
+		# Example 3: 60 sec => 01:00
+		printf "%02d:%02d\n" $minutes $seconds
+	else
+		local minutes_rounded=$(((total_seconds + 59) / 60))
+		# Shows minutes only
+		# Example 1: 0  sec => 0m
+		# Example 2: 59 sec => 1m
+		# Example 3: 60 sec => 1m
+		printf "$((minutes_rounded))m"
+	fi
 }
 
 minutes_to_seconds() {
@@ -61,6 +67,10 @@ minutes_to_seconds() {
 
 get_notifications() {
 	get_tmux_option "$pomodoro_notifications" "off"
+}
+
+get_pomodoro_granularity_seconds() {
+	get_tmux_option "$pomodoro_granularity_seconds" "off"
 }
 
 get_sound() {

--- a/scripts/pomodoro.sh
+++ b/scripts/pomodoro.sh
@@ -13,7 +13,7 @@ pomodoro_auto_restart="@pomodoro_auto_restart"
 pomodoro_on="@pomodoro_on"
 pomodoro_complete="@pomodoro_complete"
 pomodoro_notifications="@pomodoro_notifications"
-pomodoro_granularity_seconds="@pomodoro_granularity_seconds"
+pomodoro_granularity="@pomodoro_granularity"
 pomodoro_sound="@pomodoro_sound"
 pomodoro_on_default=" 🍅"
 pomodoro_complete_default=" ✅"
@@ -43,7 +43,7 @@ format_seconds() {
 	local minutes=$((total_seconds / 60))
 	local seconds=$((total_seconds % 60))
 
-	if [ "$(get_pomodoro_granularity_seconds)" == 'on' ]; then
+	if [ "$(get_pomodoro_granularity)" == 'on' ]; then
 		# Pad minutes and seconds with zeros if necessary
 		# Formats seconds to MM:SS format
 		# Example 1: 0  sec => 00:00
@@ -69,8 +69,8 @@ get_notifications() {
 	get_tmux_option "$pomodoro_notifications" "off"
 }
 
-get_pomodoro_granularity_seconds() {
-	get_tmux_option "$pomodoro_granularity_seconds" "off"
+get_pomodoro_granularity() {
+	get_tmux_option "$pomodoro_granularity" "off"
 }
 
 get_sound() {

--- a/scripts/pomodoro.sh
+++ b/scripts/pomodoro.sh
@@ -56,7 +56,7 @@ format_seconds() {
 		# Example 1: 0  sec => 0m
 		# Example 2: 59 sec => 1m
 		# Example 3: 60 sec => 1m
-		printf "$((minutes_rounded))m"
+		printf "%sm" "$((minutes_rounded))"
 	fi
 }
 
@@ -188,7 +188,7 @@ pomodoro_status() {
 
 	if [ "$pomodoro_start_time" -eq -1 ]; then
 		echo ""
-	elif [ $difference -ge $(minutes_to_seconds $(($(get_pomodoro_duration) + $(get_pomodoro_break)))) ]; then
+	elif [ $difference -ge "$(minutes_to_seconds $(($(get_pomodoro_duration) + $(get_pomodoro_break))))" ]; then
 		pomodoro_start_time=-1
 		echo ""
 		if [ "$pomodoro_status" == 'on_break' ]; then
@@ -201,20 +201,21 @@ pomodoro_status() {
 				pomodoro_cancel true
 			fi
 		fi
-	elif [ $difference -ge "$(minutes_to_seconds $(get_pomodoro_duration))" ]; then
+	elif [ $difference -ge "$(minutes_to_seconds "$(get_pomodoro_duration)")" ]; then
 		if [ "$pomodoro_status" -eq -1 ]; then
 			send_notification "🍅 Pomodoro completed!" "Your Pomodoro has now completed"
 			write_to_file "on_break" "$POMODORO_STATUS_FILE"
 		fi
 
-		local pomodoro_duration_secs=$(minutes_to_seconds $(get_pomodoro_duration))
-		local break_duration_seconds=$(minutes_to_seconds $(get_pomodoro_break))
-		local time_left_seconds=$((-(difference - pomodoro_duration_secs - break_duration_seconds)))
-		local time_left_formatted=$(format_seconds $time_left_seconds)
+		pomodoro_duration_secs=$(minutes_to_seconds "$(get_pomodoro_duration)")
+		break_duration_seconds=$(minutes_to_seconds "$(get_pomodoro_break)")
+		time_left_seconds=$((-(difference - pomodoro_duration_secs - break_duration_seconds)))
+		time_left_formatted=$(format_seconds $time_left_seconds)
+
 		printf "$(get_tmux_option "$pomodoro_complete" "$pomodoro_complete_default")$time_left_formatted "
 	else
-		local pomodoro_duration_secs=$(minutes_to_seconds $(get_pomodoro_duration))
-		local time_left_formatted=$(format_seconds $((pomodoro_duration_secs - difference)))
+		pomodoro_duration_secs=$(minutes_to_seconds "$(get_pomodoro_duration)")
+		time_left_formatted=$(format_seconds $((pomodoro_duration_secs - difference)))
 		printf "$(get_tmux_option "$pomodoro_on" "$pomodoro_on_default")$time_left_formatted "
 	fi
 }


### PR DESCRIPTION
### Issue Details: https://github.com/olimorris/tmux-pomodoro-plus/issues/13

| Before             |  After |
:-------------------------:|:-------------------------:
![](https://user-images.githubusercontent.com/8057916/216843377-2f20f352-012e-4695-8e68-b451281ed5d3.png)  |  ![](https://user-images.githubusercontent.com/8057916/216843379-b020ac59-11b5-49fd-b727-5a5aa899832a.png)
![](https://user-images.githubusercontent.com/8057916/216843433-04061428-fd51-4aba-bb63-9e81dedf96b6.png)  |  ![](https://user-images.githubusercontent.com/8057916/216843437-7672251d-4290-4348-807a-7ffc16b5ed7a.png)



### Done ✅ 
- [x] Time comparison to show Pomodoro state (timer/break timer/done) is based on seconds & not minutes
- [x] Introduced a new function format_seconds which is used to format the minutes to the appropriate `MM:SS` format
- [x] Introduce a new option for the user to enable seconds & format_seconds to handle response based on this option
    ```
    set -g @pomodoro_granularity_seconds 'on'    # Displays the time left in `MM:SS` format
    ```
- [x] ~Figure out where to put the refresh rate of status bar every second `tmux set status-interval 1` - Also figure if there is a better way to achieve this when building Tmux plugins~ - Couldn't find any, other than setting the status interval.


### How to test these changes?
- In your tmux config, point to this branch & enable seconds option:
   ```
   set -g @plugin 'PezCoder/tmux-pomodoro-plus#issues/13/show-seconds'

   set -g @pomodoro_granularity_seconds 'on'    # Displays the time left in `MM:SS` format

   set -g status-interval 1 # Makes sure tmux updates the status bar every second
   ```
- Remove the original version from TPM:
   ```
   rm -rf ~/.tmux/plugins/tmux-pomodoro-plus
   ```
- Trigger TPM install prefix + `I`
- Reload tmux config (or restart tmux)
- Optional: You can set the option to configure pomodoro timer to be 1 minutes - to test break scenarios