### PR TITLE
feat: add auto_start_break feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ set -g @plugin 'olimorris/tmux-pomodoro-plus'
 ## :rocket: Usage
 
 ### Default keybindings
-- `<tmux-prefix> p` to start a pomodoro
+- `<tmux-prefix> p` to start a pomodoro/break
 - `<tmux-prefix> P` to cancel a pomodoro
 - `<tmux-prefix> C-p` to open the pomodoro timer menu
 - `<tmux-prefix> M-p` to set a custom pomodoro timer
@@ -72,14 +72,16 @@ set -g status-right "#{pomodoro_status}"
 The default configuration:
 
 ```bash
-set -g @pomodoro_start 'p'                  # Start a Pomodoro with tmux-prefix + p
+set -g @pomodoro_start 'p'                  # Start a Pomodoro or start break with tmux-prefix + p
 set -g @pomodoro_cancel 'P'                 # Cancel a Pomodoro with tmux-prefix key + P
 
 set -g @pomodoro_mins 25                    # The duration of the pomodoro
 set -g @pomodoro_break_mins 5               # The duration of the break after the pomodoro
 set -g @pomodoro_repeat false               # Auto-repeat the pomodoro? False by default
+set -g @pomodoro_auto_start_break true      # Auto-start break when pomodoro end? True by default
 
 set -g @pomodoro_on " 🍅"                   # The formatted output when the pomodoro is running
+set -g @pomodoro_ask_break " 🕤 break?"     # The formatted output when wait to start break
 set -g @pomodoro_complete " ✅"             # The formatted output when the break is running
 
 set -g @pomodoro_notifications 'off'        # Enable desktop notifications from your terminal

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -38,3 +38,15 @@ write_to_file() {
 	local file=$2
 	echo "$data" >"$file"
 }
+
+debug_log () {
+    # add log print into the code (debug_log "hello from tmux_pomodoro_plus)"
+    # set true to enable log messages
+    # follow the log using "tail -f /tmp/tmux_pomodoro_debug_log/log.txt"
+    if true ; then
+        DIR="/tmp/tmux_pomodoro_debug_log/"
+        FILE="log.txt"
+        mkdir -p $DIR
+        echo "$(date +%T) " "$1" >> "$DIR/$FILE"
+    fi
+}


### PR DESCRIPTION
Inspired by a feature that another pomodoro app provides (https://pomofocus.io/)

Explanatory commit message:

```
Add auto_start_break feature that prevent break time to start automatically so,
after the pomodoro focus time end, user has to manually start the break.
This way user can choose when start the break time based on what it's doing.

The flow is:

- start pomodoro focus time     - user action (<tmux-prefix> p)
- focus time...
- end focus time, ask for a break
- wait for a break...
- start pomodoro break time     - user action(<tmux-prefix> p)
- break time...
- end pomodoro

The auto_start_break feature is disable by default.
```

I would like to enable by default this feature because I found very useful end things I'm working on and then start the break, but I'll let you choose this @olimorris.