### PR TITLE
fix: interpolate all interpolation strings

### DIFF
--- a/pomodoro.tmux
+++ b/pomodoro.tmux
@@ -68,7 +68,7 @@ set_keybindings() {
 
 do_interpolation() {
 	local string="$1"
-	local interpolated="${string/$pomodoro_status_interpolation_string/$pomodoro_status}"
+	local interpolated="${string//$pomodoro_status_interpolation_string/$pomodoro_status}"
 	echo "$interpolated"
 }
 


### PR DESCRIPTION
This PR fix the bug that two interpolation string exist and only one will be interpolated.
