### PR TITLE
Replace example of deprecated setting with updated setting example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ set -g @pomodoro_prompt_pomodoro "#[fg=$color_gray]🕤 ? "
 The current and total number of intervals can also be displayed:
 
 ```bash
-set -g @pomodoro_show_intervals "#[fg=$color_gray][%s/%s]"
+set -g @pomodoro_interval_display "[%s/%s]"
 ```
 
 > **Note**: If you provide just 1 `%s` then the current interval count will be displayed only


### PR DESCRIPTION
Replacing `pomodoro_show_intervals` with `pomodoro_interval_display` shows interval in status bar. Below is a screenshot showing the interval in status bar and use of updated setting (highlighted line 81)

<img width="1440" alt="Screenshot 2024-01-07 at 6 29 38 PM" src="https://github.com/olimorris/tmux-pomodoro-plus/assets/8214491/7b4e9241-d05a-4748-b3b0-e3f3dafe7791">
