### PR TITLE
Allow breaks to be disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ set -g @pomodoro_break_mins 5                  # The duration of the break after
 set -g @pomodoro_intervals 4                   # The number of intervals before a longer break is started
 set -g @pomodoro_long_break_mins 25            # The duration of the long break
 set -g @pomodoro_repeat 'off'                  # Automatically repeat the Pomodoros?
+set -g @pomodoro_disable_breaks 'off'          # Turn off breaks
 
 set -g @pomodoro_on " 🍅"                      # The formatted output when the Pomodoro is running
 set -g @pomodoro_complete " ✔︎"                 # The formatted output when the break is running

--- a/scripts/pomodoro.sh
+++ b/scripts/pomodoro.sh
@@ -40,6 +40,7 @@ pomodoro_interval_display="@pomodoro_interval_display"
 pomodoro_sound="@pomodoro_sound"
 pomodoro_notifications="@pomodoro_notifications"
 pomodoro_granularity="@pomodoro_granularity"
+pomodoro_disable_breaks="@pomodoro_disable_breaks"
 
 # ______________________________________________________________| methods |__ ;
 
@@ -67,6 +68,10 @@ get_pomodoro_long_break() {
 
 get_pomodoro_repeat() {
 	get_tmux_option "$pomodoro_repeat" "off"
+}
+
+get_pomodoro_disable_breaks() {
+	get_tmux_option "$pomodoro_disable_breaks" "off"
 }
 
 get_seconds() {
@@ -377,6 +382,7 @@ pomodoro_status() {
 	start_time=$(read_file "$START_FILE")
 	elapsed_time=$((current_time - start_time - time_paused_for))
 	pomodoro_duration="$(minutes_to_seconds "$(get_pomodoro_duration)")"
+	disable_breaks=$(get_pomodoro_disable_breaks)
 
 	# ___________________________________________________| statusline |__ ;
 
@@ -428,7 +434,7 @@ pomodoro_status() {
 	# ________________________________________________________| break |__ ;
 
 	# Pomodoro completed, starting the break
-	if [ "$pomodoro_completed" = true ] && [ "$pomodoro_status" == "in_progress" ]; then
+	if [ "$pomodoro_completed" = true ] && [ "$pomodoro_status" == "in_progress" ] && [ "$disable_breaks" != "on" ]; then
 		pomodoro_status="break"
 		remove_time_paused_file
 
@@ -445,6 +451,20 @@ pomodoro_status() {
 
 		set_status "$pomodoro_status"
 		break_start
+		return 0
+	fi
+
+	# Breaks are disabled
+	if [ "$pomodoro_completed" = true ] && [ "$pomodoro_status" == "in_progress" ] && [ "$disable_breaks" == "on" ]; then
+		remove_time_paused_file
+
+		if prompt_user; then
+			set_status "waiting_for_pomodoro"
+			send_notification "🍅 Pomodo completed!" "Start a new Pomodoro?"
+			return 0
+		fi
+
+		pomodoro_start
 		return 0
 	fi
 


### PR DESCRIPTION
Great tool! 

Personally the way I use Pomodoro is I physically step away from the computer and set a separate timer for my breaks, and only use the computer timer for the actual pomodoros.

I can hack support for this by setting break lengths to zero but maybe this is a feature that could be supported by the plugin itself? 

But I would of course understand if you wanted to stick to the textbook Pomodoro workflow. 

Tested on my machine (OSX) and it seems to work as expected.