### PR TITLE
Allow skipping when paused

### DIFF
--- a/scripts/pomodoro.sh
+++ b/scripts/pomodoro.sh
@@ -296,6 +296,7 @@ pomodoro_cancel() {
 }
 
 pomodoro_skip() {
+	remove_file "$PAUSED_FILE"
 	pomodoro_status="$(read_status)"
 
 	if [ "$pomodoro_status" = "in_progress" ]; then


### PR DESCRIPTION
Without this, the status doesn't move on until you un-pause.

Not sure if other files should be deleted here as well?
- `TIME_PAUSED_FOR_FILE`
- `FROZEN_DISPLAY_FILE` 

It looks like maybe it doesn't matter if they're hanging around since they're only looked at when resuming from paused (??), but maybe it's good to clean them up, since we're effectively abandoning the paused state here?

Tested by running `./scripts/pomodoro skip`, but I'm not sure how to test through Tmux.