### PR TITLE
Action: restart a pomodoro

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ set -g @plugin 'olimorris/tmux-pomodoro-plus'
 - `<tmux-prefix> p` to toggle between starting/pausing a Pomodoro/break
 - `<tmux-prefix> P` to cancel a Pomodoro/break
 - `<tmux-prefix> _` to skip a Pomodoro/break
+- `<tmux-prefix> e` to restart a Pomodoro
 - `<tmux-prefix> C-p` to open the Pomodoro timer menu
 - `<tmux-prefix> M-p` to set a custom Pomodoro timer
 

--- a/pomodoro.tmux
+++ b/pomodoro.tmux
@@ -10,6 +10,8 @@ POMODORO_USER_LONG_BREAK_MINS_FILE="$CURRENT_DIR/scripts/user_long_break_mins.tx
 
 default_toggle_pomodoro="p"
 toggle_pomodoro="@pomodoro_toggle"
+default_restart_pomodoro="e"
+restart_pomodoro="@pomodoro_restart"
 default_skip_pomodoro="_"
 skip_pomodoro="@pomodoro_skip"
 default_cancel_pomodoro="P"
@@ -58,6 +60,11 @@ set_keybindings() {
 	skip_binding=$(get_tmux_option "$skip_pomodoro" "$default_skip_pomodoro")
 	for key in $skip_binding; do
 		tmux bind-key -N "Skip a Pomodoro/break" "$key" run-shell "$CURRENT_DIR/scripts/pomodoro.sh skip"
+	done
+
+	restart_binding=$(get_tmux_option "$restart_pomodoro" "$default_restart_pomodoro")
+	for key in $restart_binding; do
+		tmux bind-key -N "Restart a Pomodoro" "$key" run-shell "$CURRENT_DIR/scripts/pomodoro.sh restart"
 	done
 
 	cancel_binding=$(get_tmux_option "$cancel_pomodoro" "$default_cancel_pomodoro")

--- a/scripts/pomodoro.sh
+++ b/scripts/pomodoro.sh
@@ -261,16 +261,25 @@ increment_interval() {
 }
 
 pomodoro_start() {
+	local verb=${1:-start}
+
 	clean_env
 	mkdir -p $POMODORO_DIR
 	write_to_file "$(get_seconds)" "$START_FILE"
 
 	set_status "in_progress"
-	increment_interval
+
+	if [ "$verb" = start ]; then
+		increment_interval
+	fi
 
 	refresh_statusline
-	send_notification "🍅 Pomodoro started!" "Your Pomodoro is underway"
+	send_notification "🍅 Pomodoro ${verb}ed!" "Your Pomodoro is underway"
 	return 0
+}
+
+pomodoro_restart() {
+	pomodoro_start restart
 }
 
 break_start() {
@@ -490,6 +499,8 @@ main() {
 		pomodoro_toggle
 	elif [ "$cmd" = "start" ]; then
 		pomodoro_start
+	elif [ "$cmd" = "restart" ]; then
+		pomodoro_restart
 	elif [ "$cmd" = "skip" ]; then
 		pomodoro_skip
 	elif [ "$cmd" = "cancel" ]; then


### PR DESCRIPTION
Sometimes I mess up and don't realise I've already had a timer running.

This adds a binding to restart the timer without incrementing the number of pomodoros or having to skip through a break.

Tested the script part by running ./scripts/pomodoro.sh restart, but I'm not sure how to test through Tmux.