### PR TITLE
feat(notification): add custom notification

### DIFF
--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -68,13 +68,31 @@ send_notification() {
 	if [ "$(get_notifications)" == 'on' ]; then
 		local title=$1
 		local message=$2
+		sound_file=$(get_sound_file)
 		sound=$(get_sound)
+		export sound_file
 		export sound
 		case "$OSTYPE" in
 		linux* | *bsd*)
 			notify-send -t 8000 "$title" "$message"
 			if [[ "$sound" == "on" ]]; then
-				beep -D 1500
+				if command -v pw-play &>/dev/null && [[ "$sound_file" != "off" ]]; then
+					if [[ -f $sound_file ]]; then
+						echo "pw-play \"$sound_file\"" | at now
+					else
+						sound_file="/usr/share/sounds/freedesktop/stereo/bell.oga"
+						echo "pw-play \"$sound_file\"" | at now
+					fi
+				elif command -v paplay &>/dev/null && [[ "$sound_file" != "off" ]]; then
+					if [[ -f $sound_file ]]; then
+						echo "paplay \"$sound_file\"" | at now
+					else
+						sound_file="/usr/share/sounds/freedesktop/stereo/bell.oga"
+						echo "paplay \"$sound_file\"" | at now
+					fi
+				elif command -v beep &>/dev/null; then
+					beep -D 1500
+				fi
 			fi
 			;;
 		darwin*)

--- a/scripts/pomodoro.sh
+++ b/scripts/pomodoro.sh
@@ -40,6 +40,7 @@ pomodoro_prompt_pomodoro_default=" ⏱︎ start?"
 pomodoro_interval_display="@pomodoro_interval_display"
 
 pomodoro_sound="@pomodoro_sound"
+pomodoro_sound_file="@pomodoro_sound_file"
 pomodoro_notifications="@pomodoro_notifications"
 pomodoro_granularity="@pomodoro_granularity"
 pomodoro_disable_breaks="@pomodoro_disable_breaks"
@@ -90,6 +91,10 @@ get_pomodoro_granularity() {
 
 get_sound() {
 	get_tmux_option "$pomodoro_sound" "off"
+}
+
+get_sound_file() {
+	get_tmux_option "$pomodoro_sound_file" "off"
 }
 
 format_seconds() {


### PR DESCRIPTION
# Changes

## New config

```bash
set -g @pomodoro_sound_file 'path/to/bell.wave'
# set -g @pomodoro_sound_file '/usr/share/sounds/freedesktop/stereo/bell.oga'
```
## Why

The notification sound wasn't working, likely due to hardware incompatibility. I tried following the Arch Linux documentation, but none of the suggested solutions worked for me.

## Dependencies

Depending on the Linux distribution, some dependencies may already be pre-installed.

- [sound-theme-freedesktop](https://archlinux.org/packages/extra/any/sound-theme-freedesktop/)
  Provides sound theme files for desktop notifications. Install this package if
  you want standard notification sounds like bell.oga to
  be available.
- [at](https://archlinux.org/packages/extra/x86_64/at/)
  A command-line utility that allows you to schedule tasks to run at a specified
  time.
- [pw-cat (for pipewire)](https://man.archlinux.org/man/pw-cat.1.en)
  A command-line utility for playing and recording audio streams using PipeWire.
  Use pw-cat to play sound files if you're using PipeWire.
- [paplay (for pulseaudio)](https://wiki.archlinux.org/title/Pacat)
  A command-line utility for playing sound files using PulseAudio. If you’re
  using PulseAudio, paplay is the recommended tool for sound playback.

## Tested

- [x] PopOs: everything worked out of the box.
- [x] Arch Linux: Only needed to install the `at` package, and enable atd service: `sudo systemctl enable atd`

