### PR TITLE
Multi Line Pomodoro Support

### DIFF
--- a/pomodoro.tmux
+++ b/pomodoro.tmux
@@ -93,6 +93,13 @@ main() {
 	set_keybindings
 	update_tmux_option "status-right"
 	update_tmux_option "status-left"
+
+	local lines=$(get_tmux_option "status")
+	if [[ "$lines" =~ ^[0-9]+$ ]] && [ "$lines" -ge 2 ]; then
+	 	for (( i = 1; i < lines; i++ )); do
+			update_tmux_option "status-format[$i]"
+		done
+	fi
 }
 
 main


### PR DESCRIPTION
I use tmux status in multiline. I noticed that it is not interpolated except `status-left` and `status-right`