### PR TITLE
feat: add linux custom sound

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ set -g @pomodoro_prompt_pomodoro " ⏱︎ start?"   # The formatted output when 
 
 set -g @pomodoro_menu_position "R"             # The location of the menu relative to the screen
 set -g @pomodoro_sound 'off'                   # Sound for desktop notifications (Run `ls /System/Library/Sounds` for a list of sounds to use on Mac)
+                                               # (On Linux add `on` to use the `beep` program or add your custom beeping command)
+
 set -g @pomodoro_notifications 'off'           # Enable desktop notifications from your terminal
 set -g @pomodoro_granularity 'off'             # Enables MM:SS (ex: 00:10) format instead of the default (ex: 1m)
 ```

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -68,20 +68,25 @@ send_notification() {
 	if [ "$(get_notifications)" == 'on' ]; then
 		local title=$1
 		local message=$2
+		local finished=${3:-false}
 		sound=$(get_sound)
 		export sound
 		case "$OSTYPE" in
 		linux* | *bsd*)
 			notify-send -t 8000 "$title" "$message"
-			if [[ "$sound" == "on" ]]; then
-				beep -D 1500
+			if $finished; then
+				if [[ "$sound" == "on" ]]; then
+					beep -D 1500
+				elif [[ "$sound" != "off" ]]; then
+					$sound
+				fi
 			fi
 			;;
 		darwin*)
-			if [[ "$sound" == "off" ]]; then
-				osascript -e 'display notification "'"$message"'" with title "'"$title"'"'
-			else
+			if [[ "$sound" != "off" ]] && $finished; then
 				osascript -e 'display notification "'"$message"'" with title "'"$title"'" sound name "'"$sound"'"'
+			else
+				osascript -e 'display notification "'"$message"'" with title "'"$title"'"'
 			fi
 			;;
 		esac

--- a/scripts/pomodoro.sh
+++ b/scripts/pomodoro.sh
@@ -453,7 +453,7 @@ pomodoro_status() {
 		if prompt_user; then
 			pomodoro_status="waiting_for_break"
 			set_status "$pomodoro_status"
-			send_notification "🍅 Pomodoro completed!" "Start the break now?"
+			send_notification "🍅 Pomodoro completed!" "Start the break now?" true
 			return 0
 		fi
 
@@ -472,7 +472,7 @@ pomodoro_status() {
 
 		if prompt_user; then
 			set_status "waiting_for_pomodoro"
-			send_notification "🍅 Pomodo completed!" "Start a new Pomodoro?"
+			send_notification "🍅 Pomodo completed!" "Start a new Pomodoro?" true
 			return 0
 		fi
 
@@ -506,7 +506,7 @@ pomodoro_status() {
 
 		if prompt_user; then
 			set_status "waiting_for_pomodoro"
-			send_notification "🍅 Break completed!" "Start the Pomodoro?"
+			send_notification "🍅 Break completed!" "Start the Pomodoro?" true
 			return 0
 		fi
 


### PR DESCRIPTION
I ran into some issues with configuring `beep` to work with Pulsewire on Arch so I added customization for the sound parameter on Linux, like `set -g @pomodoro_sound 'paplay $HOME/.config/tmux/ping.mp3'`

- additionally the sound is only played when a session finishes
- the previous version also played the sound when startin&pausing&resuming (Let me know what you think about this @olimorris) 